### PR TITLE
Object select fix and source attribute ANSI quoted

### DIFF
--- a/decomposed/extensions/MDDE_LDM/ExtendedModelDefinition/a_CheckGlobalScript.xml
+++ b/decomposed/extensions/MDDE_LDM/ExtendedModelDefinition/a_CheckGlobalScript.xml
@@ -213,7 +213,7 @@ Function SelectSourceObjectAttribute(objSourceObject)
          Exit Function
       End If
    
-      &#39; Get a reference the real source object
+      &#39; Get a reference to the real source object
       Dim objRealSourceObject : Set objRealSourceObject = GetRealObject(objSourceObject.GetExtendedAttribute(&quot;mdde_JoinedObject&quot;))
       
       &#39; If the selected source object is a scalar business rule, we automatically set the output attribute here without showing the object picker (if there is only one output attribute).
@@ -223,13 +223,13 @@ Function SelectSourceObjectAttribute(objSourceObject)
          For Each objAttribute in objRealSourceObject.Attributes
             &#39; If the current attribute is an output attribute, select this one (for now, if it turns output there where multiple outputs, the variable will be unset later and object picker will be shown).
             If objAttribute.HasStereotype(&quot;mdde_OutputAttribute&quot;) Then
-               Set SelectMappingSourceAttribute = objAttribute
+               Set SelectSourceObjectAttribute = objAttribute
                intOutputAttributeCount = intOutputAttributeCount + 1
             End If
          Next
          
          &#39; Of the output attribute wasn&#39;t found, show an error and stop the method.   
-         If SelectMappingSourceAttribute Is Nothing Then
+         If intOutputAttributeCount = 0 Then
             MsgBox _
                 &quot;The selected scalar business rule doesn&#39;t have an output attribute!&quot; &amp; vbCrLf &amp; vbCrLf _
                   &amp; &quot;Please make sure there is only one attribute in the scalar business rule with the stereotype &#39;Output attribute (MDDE)&#39;.&quot; _
@@ -238,7 +238,7 @@ Function SelectSourceObjectAttribute(objSourceObject)
             Exit Function
          &#39; If there are multiple output attributes, show the object picker.
          ElseIf intOutputAttributeCount &gt; 1 Then
-            Set SelectMappingSourceAttribute = Nothing
+            Set SelectSourceObjectAttribute = Nothing
          End If
       End If   
          

--- a/decomposed/extensions/MDDE_LDM/Profile/BaseClassifierMapping/Criteria/mdde_Criterion_IsMDDEMapping/Criteria/mdde_Criterion_ClassifierIsPivotBusinessRule/Templates/mdde_Mapping_Stereotyped_XmlExport_Template.xml
+++ b/decomposed/extensions/MDDE_LDM/Profile/BaseClassifierMapping/Criteria/mdde_Criterion_IsMDDEMapping/Criteria/mdde_Criterion_ClassifierIsPivotBusinessRule/Templates/mdde_Mapping_Stereotyped_XmlExport_Template.xml
@@ -3,10 +3,10 @@
 <a:Name>mdde_Mapping_Stereotyped_XmlExport_Template</a:Name>
 <a:TemplateTargetItem.Value>&lt;PivotConfig
 .if (%mdde_PivotHeaderAttributeSelector%)
- PivotHeaderAttribute=&quot;%mdde_PivotAggregatedAttribute_SourceObject.Code%.%mdde_PivotHeaderAttribute.Code%&quot;
+ PivotHeaderAttribute=&quot;&amp;quot;%mdde_PivotAggregatedAttribute_SourceObject.Code%&amp;quot;.&amp;quot;%mdde_PivotHeaderAttribute.Code%&amp;quot;&quot;
 .endif()
 .if (%mdde_PivotAggregatedAttributeSelector%)
- PivotAggregatedAttribute=&quot;%mdde_PivotAggregatedAttribute_SourceObject.Code%.%mdde_PivotAggregatedAttribute.Code%&quot;
+ PivotAggregatedAttribute=&quot;&amp;quot;%mdde_PivotAggregatedAttribute_SourceObject.Code%&amp;quot;.&amp;quot;%mdde_PivotAggregatedAttribute.Code%&amp;quot;&quot;
 .endif()
 .if (%mdde_PivotAggregateFunction%)
  PivotAggregateFunction=&quot;%.X:mdde_PivotAggregateFunction%&quot;

--- a/decomposed/extensions/MDDE_LDM/Profile/BaseStructuralFeatureMapping/Criteria/mdde_Criterion_ParentIsMDDEMapping/Templates/mdde_BaseStructuralFeatureMapping_SourceAttribute_XmlExport_Template.xml
+++ b/decomposed/extensions/MDDE_LDM/Profile/BaseStructuralFeatureMapping/Criteria/mdde_Criterion_ParentIsMDDEMapping/Templates/mdde_BaseStructuralFeatureMapping_SourceAttribute_XmlExport_Template.xml
@@ -6,7 +6,7 @@
   .if (%SourceFeature%)
     .comment If the source object is also known, the mapping is correct and we present the source attribute.
     .if (%mdde_SourceObject%)
-%mdde_SourceObject.Code%.%SourceFeature.Code%
+&quot;%mdde_SourceObject.Code%&quot;.&quot;%SourceFeature.Code%&quot;
     .endif
   .comment If the mapped to value is a numeric value or encapsulated in single quotes, it&#39;s a static value.
   .elsif (%mdde_IsLiteralValue%)

--- a/decomposed/extensions/MDDE_LDM/Profile/BaseStructuralFeatureMapping/Criteria/mdde_Criterion_ParentIsMDDEMapping/Templates/mdde_BaseStructuralFeatureMapping_XmlExport_Template.xml
+++ b/decomposed/extensions/MDDE_LDM/Profile/BaseStructuralFeatureMapping/Criteria/mdde_Criterion_ParentIsMDDEMapping/Templates/mdde_BaseStructuralFeatureMapping_XmlExport_Template.xml
@@ -3,7 +3,7 @@
 <a:Name>mdde_BaseStructuralFeatureMapping_XmlExport_Template</a:Name>
 <a:TemplateTargetItem.Value>&lt;%Feature.mdde_NamedObject_XmlElementName%Mapping Id=&quot;%ObjectID%&quot; TargetAttribute=&quot;%Feature.Code%&quot;
 .if (%mdde_BaseStructuralFeatureMapping_SourceAttribute_XmlExport_Template%)
- SourceAttribute=&quot;%mdde_BaseStructuralFeatureMapping_SourceAttribute_XmlExport_Template%&quot; IsLiteralValue=&quot;%mdde_IsLiteralValue%&quot;
+ SourceAttribute=&quot;%.X:mdde_BaseStructuralFeatureMapping_SourceAttribute_XmlExport_Template%&quot; IsLiteralValue=&quot;%mdde_IsLiteralValue%&quot;
 .endif()
 .comment Add the Aggregate function if it is specified.
 .if (%mdde_Aggregate?%)

--- a/decomposed/extensions/MDDE_LDM/Profile/ExtendedSubObject/Stereotypes/mdde_JoinCondition/Templates/mdde_JoinCondition_ParentAttribute_XmlExport_Template.xml
+++ b/decomposed/extensions/MDDE_LDM/Profile/ExtendedSubObject/Stereotypes/mdde_JoinCondition/Templates/mdde_JoinCondition_ParentAttribute_XmlExport_Template.xml
@@ -5,7 +5,7 @@
 .if %mdde_ParentLiteralValue%
 %mdde_ParentLiteralValue%
 .elsif (%mdde_ParentSourceObject%) &amp;&amp; (%mdde_ParentAttribute%)
-%mdde_ParentSourceObject.Code%.%mdde_ParentAttribute.Code%
+&amp;quot;%mdde_ParentSourceObject.Code%&amp;quot;.&amp;quot;%mdde_ParentAttribute.Code%&amp;quot;
 .endif</a:TemplateTargetItem.Value>
 <a:CreationDate>1654155830</a:CreationDate>
 <a:Creator>WesselsH1</a:Creator>

--- a/decomposed/models/ExampleDWH/EXAMPLEDWH.model.xml
+++ b/decomposed/models/ExampleDWH/EXAMPLEDWH.model.xml
@@ -25,11 +25,11 @@
             </SourceObject>
           </SourceObjects>
           <AttributeMappings>
-            <AttributeMapping Id="B05C5CB2-6CEC-4E49-92AF-9546796D9FC4" TargetAttribute="CUSTOMERID" SourceAttribute="SalesOrder.CUSTOMERID" IsLiteralValue="false">
+            <AttributeMapping Id="B05C5CB2-6CEC-4E49-92AF-9546796D9FC4" TargetAttribute="CUSTOMERID" SourceAttribute="&quot;SalesOrder&quot;.&quot;CUSTOMERID&quot;" IsLiteralValue="false">
               <TargetAttribute Id="40CF0476-2BED-40C9-B805-F2B1FC7A91B4" Code="CUSTOMERID" Name="CustomerId" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="2FBD5275-6AB7-489E-8CC5-B5CFBD2C0187" Id="EC1D061C-A80C-45FC-9210-404133B3EAC3" Code="CUSTOMERID" Name="CustomerId" />
             </AttributeMapping>
-            <AttributeMapping Id="827DCDA0-95DE-4FD6-86CD-02025D301D92" TargetAttribute="TOTALREVENUE" SourceAttribute="SalesOrder.TOTALAMOUNT" IsLiteralValue="false" Aggregate="Sum">
+            <AttributeMapping Id="827DCDA0-95DE-4FD6-86CD-02025D301D92" TargetAttribute="TOTALREVENUE" SourceAttribute="&quot;SalesOrder&quot;.&quot;TOTALAMOUNT&quot;" IsLiteralValue="false" Aggregate="Sum">
               <TargetAttribute Id="FA20EE0F-7D0C-4315-A5CC-CAFF7A32C2FC" Code="TOTALREVENUE" Name="TotalRevenue" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="2FBD5275-6AB7-489E-8CC5-B5CFBD2C0187" Id="493F6607-B532-4EA0-AD55-9161F8A30CAC" Code="TOTALAMOUNT" Name="TotalAmount" />
             </AttributeMapping>
@@ -175,67 +175,67 @@
             <SourceObject Id="946186C3-8F2F-41B9-9A7D-8AB9CB4F2146" Code="Country" Name="Country" Stereotype="mdde_SourceObject" JoinedObject="Country" JoinedObjectModel="EXAMPLEDWH" JoinType="LEFT JOIN">
               <Entity Id="F7FFB923-8961-422F-9EB7-B5EA84C99262" Code="Country" Name="Country" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="CODE" JoinOperator="=" ParentAttribute="Customer.COUNTRY" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="CODE" JoinOperator="=" ParentAttribute="&quot;Customer&quot;.&quot;COUNTRY&quot;" ParentIsLiteralValue="false" />
               </JoinConditions>
             </SourceObject>
             <SourceObject Id="AEA474CB-9A03-41BC-8B68-2814C842020C" Code="Aggregate_Total_Sales_Per_Customer" Name="Aggregate Total Sales Per Customer" Stereotype="mdde_SourceObject" JoinedObject="Aggregate_Total_Sales_Per_Customer" JoinedObjectModel="EXAMPLEDWH" JoinType="LEFT JOIN">
               <AggregateBusinessRule Id="B3B5F4BC-300B-4354-87E5-B5987AA01744" Code="Aggregate_Total_Sales_Per_Customer" Name="Aggregate Total Sales Per Customer" Stereotype="mdde_AggregateBusinessRule" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="CUSTOMERID" JoinOperator="=" ParentAttribute="Customer.ID" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="CUSTOMERID" JoinOperator="=" ParentAttribute="&quot;Customer&quot;.&quot;ID&quot;" ParentIsLiteralValue="false" />
               </JoinConditions>
             </SourceObject>
             <SourceObject Id="BFE7CB1D-E29F-43F8-80A1-8A39D28FDA94" Code="Derive_Customer_FullName" Name="Derive Customer FullName" Stereotype="mdde_SourceObject" JoinedObject="Derive_Customer_FullName" JoinedObjectModel="EXAMPLEDWH" JoinType="APPLY">
               <ScalarBusinessRule Id="FEEBABF2-3F57-42F3-B5AB-485037997805" Code="Derive_Customer_FullName" Name="Derive Customer FullName" Stereotype="mdde_ScalarBusinessRule" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="FIRST_NAME" JoinOperator="=" ParentAttribute="Customer.FIRSTNAME" ParentIsLiteralValue="false" />
-                <JoinCondition ChildAttribute="LAST_NAME" JoinOperator="=" ParentAttribute="Customer.LASTNAME" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="FIRST_NAME" JoinOperator="=" ParentAttribute="&quot;Customer&quot;.&quot;FIRSTNAME&quot;" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="LAST_NAME" JoinOperator="=" ParentAttribute="&quot;Customer&quot;.&quot;LASTNAME&quot;" ParentIsLiteralValue="false" />
               </JoinConditions>
             </SourceObject>
             <SourceObject Id="6DB43891-22B1-48D1-8BDC-27987FA6D4D0" Code="Filter_FromNL" Name="Filter_FromNL" Stereotype="mdde_SourceObject" JoinedObject="Filter_FromNL" JoinedObjectModel="EXAMPLEDWH" JoinType="APPLY">
               <FilterBusinessRule Id="E1395C49-53C1-4F30-A69D-5E523DF67CD1" Code="Filter_FromNL" Name="Filter_FromNL" Stereotype="mdde_FilterBusinessRule" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="COUNTRY_CODE" JoinOperator="=" ParentAttribute="Country.CODE" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="COUNTRY_CODE" JoinOperator="=" ParentAttribute="&quot;Country&quot;.&quot;CODE&quot;" ParentIsLiteralValue="false" />
               </JoinConditions>
             </SourceObject>
           </SourceObjects>
           <AttributeMappings>
-            <AttributeMapping Id="BDF4592B-823E-48F2-A044-4791AA547000" TargetAttribute="CUSTOMERID" SourceAttribute="Customer.ID" IsLiteralValue="false">
+            <AttributeMapping Id="BDF4592B-823E-48F2-A044-4791AA547000" TargetAttribute="CUSTOMERID" SourceAttribute="&quot;Customer&quot;.&quot;ID&quot;" IsLiteralValue="false">
               <TargetAttribute Id="821996D6-42E2-4246-8CCF-60B3B757B5E2" Code="CUSTOMERID" Name="CustomerId" Stereotype="xm_businessKey" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="Customer" SourceObjectId="BD5952F1-0868-4FC7-A3AC-273126B9E7AA" Id="071EB08F-6D7D-428D-BBB0-14B5B9D81201" Code="ID" Name="Id" />
             </AttributeMapping>
-            <AttributeMapping Id="7CBB89CA-D319-4CC8-B6B9-4D8E187C001C" TargetAttribute="FULLNAME" SourceAttribute="Derive_Customer_FullName.FULL_NAME" IsLiteralValue="false">
+            <AttributeMapping Id="7CBB89CA-D319-4CC8-B6B9-4D8E187C001C" TargetAttribute="FULLNAME" SourceAttribute="&quot;Derive_Customer_FullName&quot;.&quot;FULL_NAME&quot;" IsLiteralValue="false">
               <TargetAttribute Id="706B5392-B8A5-4BD5-B3D1-ABCF4AAF1E97" Code="FULLNAME" Name="FullName" Stereotype="xm_attribute" />
               <SourceAttribute Entity="Derive_Customer_FullName" SourceObjectId="BFE7CB1D-E29F-43F8-80A1-8A39D28FDA94" Id="C979CF59-70EA-4B3F-B2FE-2919D9BABF85" Code="FULL_NAME" Name="Full Name" Stereotype="mdde_OutputAttribute" />
             </AttributeMapping>
-            <AttributeMapping Id="E0980325-A2FE-44ED-BFE1-2AC1141A1478" TargetAttribute="COUNTRY_DESCRIPTION" SourceAttribute="Country.DESCRIPTION" IsLiteralValue="false">
+            <AttributeMapping Id="E0980325-A2FE-44ED-BFE1-2AC1141A1478" TargetAttribute="COUNTRY_DESCRIPTION" SourceAttribute="&quot;Country&quot;.&quot;DESCRIPTION&quot;" IsLiteralValue="false">
               <TargetAttribute Id="AEED4C8F-1536-4AA3-9882-2995E0D50FA8" Code="COUNTRY_DESCRIPTION" Name="Country_Description" Stereotype="xm_attribute" />
               <SourceAttribute Entity="Country" SourceObjectId="946186C3-8F2F-41B9-9A7D-8AB9CB4F2146" Id="80ED7852-37E8-48C0-ADE2-B41FA9231ECB" Code="DESCRIPTION" Name="Description" Stereotype="xm_attribute" />
             </AttributeMapping>
-            <AttributeMapping Id="91B33699-A24B-4765-96D4-E39A9666EBE8" TargetAttribute="FIRSTNAME" SourceAttribute="Customer.FIRSTNAME" IsLiteralValue="false">
+            <AttributeMapping Id="91B33699-A24B-4765-96D4-E39A9666EBE8" TargetAttribute="FIRSTNAME" SourceAttribute="&quot;Customer&quot;.&quot;FIRSTNAME&quot;" IsLiteralValue="false">
               <TargetAttribute Id="1C25B8C3-87B8-4ADD-846B-148F70ED6FA7" Code="FIRSTNAME" Name="FirstName" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="Customer" SourceObjectId="BD5952F1-0868-4FC7-A3AC-273126B9E7AA" Id="E15BA61C-22E8-480F-8854-32B66E2001C0" Code="FIRSTNAME" Name="FirstName" />
             </AttributeMapping>
-            <AttributeMapping Id="7450411C-66AE-4CAF-B9D7-0A8585A4C409" TargetAttribute="LASTNAME" SourceAttribute="Customer.LASTNAME" IsLiteralValue="false">
+            <AttributeMapping Id="7450411C-66AE-4CAF-B9D7-0A8585A4C409" TargetAttribute="LASTNAME" SourceAttribute="&quot;Customer&quot;.&quot;LASTNAME&quot;" IsLiteralValue="false">
               <TargetAttribute Id="9C9F9B92-807D-44E9-8126-B49E00833C72" Code="LASTNAME" Name="LastName" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="Customer" SourceObjectId="BD5952F1-0868-4FC7-A3AC-273126B9E7AA" Id="B47EB33C-682A-4199-845A-C2B47D086F72" Code="LASTNAME" Name="LastName" />
             </AttributeMapping>
-            <AttributeMapping Id="7C59874E-B341-47F4-800C-A53D43F01E18" TargetAttribute="CITY" SourceAttribute="Customer.CITY" IsLiteralValue="false">
+            <AttributeMapping Id="7C59874E-B341-47F4-800C-A53D43F01E18" TargetAttribute="CITY" SourceAttribute="&quot;Customer&quot;.&quot;CITY&quot;" IsLiteralValue="false">
               <TargetAttribute Id="80FDED88-4CF0-4708-8E2C-87910197B915" Code="CITY" Name="City" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="Customer" SourceObjectId="BD5952F1-0868-4FC7-A3AC-273126B9E7AA" Id="99AAF098-A167-4D36-90B7-54A482421D21" Code="CITY" Name="City" />
             </AttributeMapping>
-            <AttributeMapping Id="45F882F2-448D-496D-9067-F2C6C91505DB" TargetAttribute="COUNTRY_CODE" SourceAttribute="Country.CODE" IsLiteralValue="false">
+            <AttributeMapping Id="45F882F2-448D-496D-9067-F2C6C91505DB" TargetAttribute="COUNTRY_CODE" SourceAttribute="&quot;Country&quot;.&quot;CODE&quot;" IsLiteralValue="false">
               <TargetAttribute Id="0219356E-AA66-4F1D-9EDA-1F6CA72D3C14" Code="COUNTRY_CODE" Name="Country_Code" Stereotype="xm_attribute" />
               <SourceAttribute Entity="Country" SourceObjectId="946186C3-8F2F-41B9-9A7D-8AB9CB4F2146" Id="5C782765-BA26-49BC-8DA4-FDFDD7538643" Code="CODE" Name="Code" Stereotype="xm_businessKey" />
             </AttributeMapping>
-            <AttributeMapping Id="32140CC0-0F76-4D44-A04D-A89CE59D7D26" TargetAttribute="COUNTRY_CONTINENT" SourceAttribute="Country.CONTINENT" IsLiteralValue="false">
+            <AttributeMapping Id="32140CC0-0F76-4D44-A04D-A89CE59D7D26" TargetAttribute="COUNTRY_CONTINENT" SourceAttribute="&quot;Country&quot;.&quot;CONTINENT&quot;" IsLiteralValue="false">
               <TargetAttribute Id="DCCFD5DD-7EFD-4EF9-AF76-DE1C9141C268" Code="COUNTRY_CONTINENT" Name="Country_Continent" Stereotype="xm_attribute" />
               <SourceAttribute Entity="Country" SourceObjectId="946186C3-8F2F-41B9-9A7D-8AB9CB4F2146" Id="8A0765A7-C0F9-4068-A63C-80884F17A8D5" Code="CONTINENT" Name="Continent" Stereotype="xm_attribute" />
             </AttributeMapping>
-            <AttributeMapping Id="389AE7C9-DD32-4659-8C7F-836726CB4719" TargetAttribute="PHONE" SourceAttribute="Customer.PHONE" IsLiteralValue="false">
+            <AttributeMapping Id="389AE7C9-DD32-4659-8C7F-836726CB4719" TargetAttribute="PHONE" SourceAttribute="&quot;Customer&quot;.&quot;PHONE&quot;" IsLiteralValue="false">
               <TargetAttribute Id="842A3F5E-3723-445B-A521-850B22378B23" Code="PHONE" Name="Phone" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="Customer" SourceObjectId="BD5952F1-0868-4FC7-A3AC-273126B9E7AA" Id="117618E5-A065-4822-86E2-61CAA2E89AF9" Code="PHONE" Name="Phone" />
             </AttributeMapping>
-            <AttributeMapping Id="0F811B22-3FC0-4A6E-ACF3-78782D9BBE04" TargetAttribute="TOTALREVENUE" SourceAttribute="Aggregate_Total_Sales_Per_Customer.TOTALREVENUE" IsLiteralValue="false">
+            <AttributeMapping Id="0F811B22-3FC0-4A6E-ACF3-78782D9BBE04" TargetAttribute="TOTALREVENUE" SourceAttribute="&quot;Aggregate_Total_Sales_Per_Customer&quot;.&quot;TOTALREVENUE&quot;" IsLiteralValue="false">
               <TargetAttribute Id="C2F71322-D757-4A94-8070-36ED006C3848" Code="TOTALREVENUE" Name="TotalRevenue" Stereotype="xm_attribute" />
               <SourceAttribute Entity="Aggregate_Total_Sales_Per_Customer" SourceObjectId="AEA474CB-9A03-41BC-8B68-2814C842020C" Id="FA20EE0F-7D0C-4315-A5CC-CAFF7A32C2FC" Code="TOTALREVENUE" Name="TotalRevenue" />
             </AttributeMapping>
@@ -320,17 +320,17 @@
             <SourceObject Id="AADE6651-C2A7-433D-BD10-B52D14E0F0CA" Code="Customer" Name="Customer" Stereotype="mdde_SourceObject" JoinedObject="Customer" JoinedObjectModel="EXAMPLESOURCE" JoinType="INNER JOIN">
               <Entity Id="1352D98F-2A9C-42AA-AE82-2E68BA514F02" Code="Customer" Name="Customer" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="ID" JoinOperator="=" ParentAttribute="SalesOrder.CUSTOMERID" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="ID" JoinOperator="=" ParentAttribute="&quot;SalesOrder&quot;.&quot;CUSTOMERID&quot;" ParentIsLiteralValue="false" />
               </JoinConditions>
             </SourceObject>
           </SourceObjects>
           <AttributeMappings>
-            <AttributeMapping Id="00CAAC6A-D28B-4102-9E15-46C6B9C24EC0" TargetAttribute="ORDERDATE" SourceAttribute="SalesOrder.ORDERDATE" IsLiteralValue="false">
+            <AttributeMapping Id="00CAAC6A-D28B-4102-9E15-46C6B9C24EC0" TargetAttribute="ORDERDATE" SourceAttribute="&quot;SalesOrder&quot;.&quot;ORDERDATE&quot;" IsLiteralValue="false">
               <TargetAttribute Id="C4547423-339C-4795-960F-92D49D53CC55" Code="ORDERDATE" Name="OrderDate" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="28920BA9-47C9-45CC-A738-6157059ABCCC" Id="FE17C4F0-5C1E-4E50-A96E-D045E816ACAF" Code="ORDERDATE" Name="OrderDate" />
             </AttributeMapping>
           </AttributeMappings>
-          <PivotConfig PivotHeaderAttribute="Customer.COUNTRY" PivotAggregatedAttribute="Customer.ID" PivotAggregateFunction="Count">
+          <PivotConfig PivotHeaderAttribute="&quot;Customer&quot;.&quot;COUNTRY&quot;" PivotAggregatedAttribute="&quot;Customer&quot;.&quot;ID&quot;" PivotAggregateFunction="Count">
             <HeaderTargetAttributes>
               <HeaderTargetAttribute HeaderValue="Netherlands" TargetAttribute="NLD" />
               <HeaderTargetAttribute HeaderValue="Germany" TargetAttribute="DEU" />
@@ -364,33 +364,33 @@
             <SourceObject Id="0F2EE1DB-8E68-424B-BBF5-0342A9EFE195" Code="Calculate_Order_Age" Name="Calculate_Order_Age" Stereotype="mdde_SourceObject" JoinedObject="Calculate_Order_Age" JoinedObjectModel="EXAMPLEDWH" JoinType="APPLY">
               <ScalarBusinessRule Id="5C9CA8A8-333C-4FC6-9C9A-84546F24EDE0" Code="Calculate_Order_Age" Name="Calculate_Order_Age" Stereotype="mdde_ScalarBusinessRule" />
               <JoinConditions>
-                <JoinCondition ChildAttribute="ORDER_DATE" JoinOperator="=" ParentAttribute="SalesOrder.ORDERDATE" ParentIsLiteralValue="false" />
+                <JoinCondition ChildAttribute="ORDER_DATE" JoinOperator="=" ParentAttribute="&quot;SalesOrder&quot;.&quot;ORDERDATE&quot;" ParentIsLiteralValue="false" />
                 <JoinCondition ChildAttribute="CURRENT_DATE" JoinOperator="=" ParentAttribute="'2023-12-31'" ParentIsLiteralValue="true" />
               </JoinConditions>
             </SourceObject>
           </SourceObjects>
           <AttributeMappings>
-            <AttributeMapping Id="339523B3-CB02-4BA0-ACD7-534F0C97FE36" TargetAttribute="ORDERID" SourceAttribute="SalesOrder.ID" IsLiteralValue="false">
+            <AttributeMapping Id="339523B3-CB02-4BA0-ACD7-534F0C97FE36" TargetAttribute="ORDERID" SourceAttribute="&quot;SalesOrder&quot;.&quot;ID&quot;" IsLiteralValue="false">
               <TargetAttribute Id="3D846A5E-5D6B-4E30-820A-1692473D8211" Code="ORDERID" Name="OrderId" Stereotype="xm_businessKey" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="40917FB0-D3E0-46A9-B991-CCC50FC38BCB" Id="3FA0D49D-8A10-4769-B683-85960E9F353F" Code="ID" Name="Id" />
             </AttributeMapping>
-            <AttributeMapping Id="9C0E4971-DA7B-4025-8181-4776750E7DD0" TargetAttribute="ORDERDATE" SourceAttribute="SalesOrder.ORDERDATE" IsLiteralValue="false">
+            <AttributeMapping Id="9C0E4971-DA7B-4025-8181-4776750E7DD0" TargetAttribute="ORDERDATE" SourceAttribute="&quot;SalesOrder&quot;.&quot;ORDERDATE&quot;" IsLiteralValue="false">
               <TargetAttribute Id="119AF58F-65A9-4302-AB5C-48125C92DC41" Code="ORDERDATE" Name="OrderDate" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="40917FB0-D3E0-46A9-B991-CCC50FC38BCB" Id="FE17C4F0-5C1E-4E50-A96E-D045E816ACAF" Code="ORDERDATE" Name="OrderDate" />
             </AttributeMapping>
-            <AttributeMapping Id="98D00E52-DFCC-4EFA-8A8C-3CC719419019" TargetAttribute="ORDERNUMBER" SourceAttribute="SalesOrder.ORDERNUMBER" IsLiteralValue="false">
+            <AttributeMapping Id="98D00E52-DFCC-4EFA-8A8C-3CC719419019" TargetAttribute="ORDERNUMBER" SourceAttribute="&quot;SalesOrder&quot;.&quot;ORDERNUMBER&quot;" IsLiteralValue="false">
               <TargetAttribute Id="C04AC16A-42B7-4C30-A8B7-4BBBFC4630AF" Code="ORDERNUMBER" Name="OrderNumber" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="40917FB0-D3E0-46A9-B991-CCC50FC38BCB" Id="485471FA-F386-4401-BDE8-7447D453FEBF" Code="ORDERNUMBER" Name="OrderNumber" />
             </AttributeMapping>
-            <AttributeMapping Id="2AED17E5-370A-4C17-9F3E-79397698C017" TargetAttribute="CUSTOMERID" SourceAttribute="SalesOrder.CUSTOMERID" IsLiteralValue="false">
+            <AttributeMapping Id="2AED17E5-370A-4C17-9F3E-79397698C017" TargetAttribute="CUSTOMERID" SourceAttribute="&quot;SalesOrder&quot;.&quot;CUSTOMERID&quot;" IsLiteralValue="false">
               <TargetAttribute Id="CDFD6CA7-C11D-49AE-9882-AC733F7943CF" Code="CUSTOMERID" Name="CustomerId" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="40917FB0-D3E0-46A9-B991-CCC50FC38BCB" Id="EC1D061C-A80C-45FC-9210-404133B3EAC3" Code="CUSTOMERID" Name="CustomerId" />
             </AttributeMapping>
-            <AttributeMapping Id="D2E4056A-5337-40EB-ABAF-69EA3B0BF3A3" TargetAttribute="TOTALAMOUNT" SourceAttribute="SalesOrder.TOTALAMOUNT" IsLiteralValue="false">
+            <AttributeMapping Id="D2E4056A-5337-40EB-ABAF-69EA3B0BF3A3" TargetAttribute="TOTALAMOUNT" SourceAttribute="&quot;SalesOrder&quot;.&quot;TOTALAMOUNT&quot;" IsLiteralValue="false">
               <TargetAttribute Id="170BF497-2F70-404A-A97D-3BAD41FE3D82" Code="TOTALAMOUNT" Name="TotalAmount" Stereotype="xm_attribute" />
               <SourceAttribute Model="EXAMPLESOURCE" Entity="SalesOrder" SourceObjectId="40917FB0-D3E0-46A9-B991-CCC50FC38BCB" Id="493F6607-B532-4EA0-AD55-9161F8A30CAC" Code="TOTALAMOUNT" Name="TotalAmount" />
             </AttributeMapping>
-            <OutputAttributeMapping Id="C05F4489-2B7B-473C-BF46-8ADD3CD0C694" TargetAttribute="AGEINDAYS" SourceAttribute="Calculate_Order_Age.ORDER_AGE_IN_DAYS" IsLiteralValue="false">
+            <OutputAttributeMapping Id="C05F4489-2B7B-473C-BF46-8ADD3CD0C694" TargetAttribute="AGEINDAYS" SourceAttribute="&quot;Calculate_Order_Age&quot;.&quot;ORDER_AGE_IN_DAYS&quot;" IsLiteralValue="false">
               <TargetAttribute Id="12F67EA7-2C9F-4D03-B063-84C354E15884" Code="AGEINDAYS" Name="AgeInDays" Stereotype="mdde_OutputAttribute" />
               <SourceAttribute Entity="Calculate_Order_Age" SourceObjectId="0F2EE1DB-8E68-424B-BBF5-0342A9EFE195" Id="742B3F05-D053-4323-9052-6D641E3BF52F" Code="ORDER_AGE_IN_DAYS" Name="Order Age In Days" Stereotype="mdde_OutputAttribute" />
             </OutputAttributeMapping>


### PR DESCRIPTION
- Fixed source object selection which accidentally was broken in previous refactoring.
- Added double quotes (ANSI style) around all object names in the XML export if it's a fully qualified object name (CUSTOMER.FIRST_NAME is now "CUSTOMER"."FIRST_NAME"). This is to solve issues with using reserved keywords in any DBMS.